### PR TITLE
[Fix] frame_table을 전역 변수로 변경 및 초기화/추가/삭제함수 수정

### DIFF
--- a/pintos-kaist/include/threads/thread.h
+++ b/pintos-kaist/include/threads/thread.h
@@ -135,7 +135,6 @@ struct thread
 #ifdef VM
 	/* Table for whole virtual memory owned by thread. */
 	struct supplemental_page_table spt;
-	struct list frame_table;
 #endif
 
 	/* Owned by thread.c. */
@@ -147,6 +146,7 @@ struct thread
    If true, use multi-level feedback queue scheduler.
    Controlled by kernel command-line option "-o mlfqs". */
 extern bool thread_mlfqs;
+extern struct list frame_table;
 
 void thread_init(void);
 void thread_start(void);

--- a/pintos-kaist/threads/thread.c
+++ b/pintos-kaist/threads/thread.c
@@ -85,6 +85,9 @@ static uint64_t gdt[3] = {0,
 
 fixed_t load_avg = 0;
 
+//vm용 프레임 테이블
+struct list frame_table;
+
 /* Initializes the threading system by transforming the code
    that's currently running into a thread.  This can't work in
    general and it is possible in this case only because loader.S
@@ -115,6 +118,7 @@ void thread_init(void)
 	list_init(&ready_list);
 	list_init(&destruction_req);
 	list_init(&all_list);
+	list_init(&frame_table);
 
 	/* Set up a thread structure for the running thread. */
 	initial_thread = running_thread();
@@ -616,9 +620,6 @@ init_thread(struct thread *t, const char *name, int priority)
 		}
 	}
 
-#ifdef VM
-	list_init(&t->frame_table);
-#endif
 	list_init(&t->children_list);
 	list_init(&t->donations);
 	list_push_back(&all_list, &t->all_elem);

--- a/pintos-kaist/vm/vm.c
+++ b/pintos-kaist/vm/vm.c
@@ -280,14 +280,14 @@ void supplemental_page_table_kill(struct supplemental_page_table *spt UNUSED)
 
 void frame_table_insert(struct list_elem *elem){
 	struct thread *cur = thread_current();
-	list_push_back(&cur->frame_table, elem);
+	list_push_back(&frame_table, elem);
 	return;
 }
 
 struct frame *frame_table_remove(void){
 	struct thread *cur = thread_current();
 	
-	if(list_empty(&cur->frame_table)) 
+	if(list_empty(&frame_table)) 
 		return NULL;
-	return list_entry(list_pop_front(&cur->frame_table), struct frame, elem);
+	return list_entry(list_pop_front(&frame_table), struct frame, elem);
 }


### PR DESCRIPTION
수정 사항 요약
-thread.c / thread.h 
  frame_table 전역 변수로 변경
  thread_init 내에서 초기화되도록 list_init 위치 변경

-vm.c
   frame_table 관련 함수 내 frame_table 경로 수정