### PR TITLE
[Fix] hash_find 무한루프 해결

### DIFF
--- a/pintos-kaist/vm/vm.c
+++ b/pintos-kaist/vm/vm.c
@@ -4,7 +4,7 @@
 #include "vm/vm.h"
 #include "vm/inspect.h"
 #include "threads/mmu.h"
-//Project 3 : VM
+// Project 3 : VM
 #include "kernel/hash.h"
 
 /* 각 서브시스템의 초기화 코드를 호출하여 가상 메모리 서브시스템을 초기화합니다. */
@@ -62,7 +62,8 @@ bool vm_alloc_page_with_initializer(enum vm_type type, void *upage, bool writabl
 		bool (*page_initializer)(struct page *, enum vm_type, void *kva);
 		struct page *page = malloc(sizeof(struct page));
 
-		if (page == NULL) {
+		if (page == NULL)
+		{
 			goto err;
 		}
 
@@ -88,10 +89,11 @@ bool vm_alloc_page_with_initializer(enum vm_type type, void *upage, bool writabl
 		uninit_new(page, upage, init, type, aux, page_initializer);
 
 		/* TODO: 생성한 페이지를 spt에 삽입하세요. */
-		if (!spt_insert_page(spt, page)) {
+		if (!spt_insert_page(spt, page))
+		{
 			// 실패 시 메모리 누수 방지 위해 free
 			free(page);
-			// 실패 했으니까 에러로 가야겠지? 
+			// 실패 했으니까 에러로 가야겠지?
 			goto err;
 		}
 
@@ -128,31 +130,34 @@ spt_find_page(struct supplemental_page_table *spt UNUSED, void *va UNUSED)
 bool spt_insert_page(struct supplemental_page_table *spt UNUSED,
 					 struct page *page UNUSED)
 {
-	//int succ = false;
+	// int succ = false;
 	/* TODO: Fill this function. */
 
 	// 예외 처리
-	if (spt == NULL || page == NULL) {
+	if (spt == NULL || page == NULL)
+	{
 		return false;
 	}
 
 	// 메모리 할당
 	struct SPT_entry *entry = malloc(sizeof(struct SPT_entry));
 	// 예외 처리
-	if (entry == NULL) {
+	if (entry == NULL)
+	{
 		return false;
 	}
 
-	entry->va = page->va;	// 가상 주소 : page 구조체의 va 필드 -> SPT_entry의 va 필드
-	entry->page = page;		// 페이지 참조 : page 구조체의 주소 -> SPT_entry의 apge 포인터
+	entry->va = page->va; // 가상 주소 : page 구조체의 va 필드 -> SPT_entry의 va 필드
+	entry->page = page;	  // 페이지 참조 : page 구조체의 주소 -> SPT_entry의 apge 포인터
 
-	if (hash_insert(&spt->SPT_hash_list, &entry->elem) != NULL) {
+	if (hash_insert(&spt->SPT_hash_list, &entry->elem) != NULL)
+	{
 		// 삽입 실패시 메모리 정리
 		free(entry);
-		return false;	// 삽입 실패
+		return false; // 삽입 실패
 	}
 
-	return true;	// SPT 페이지 삽입 성공
+	return true; // SPT 페이지 삽입 성공
 }
 
 void spt_remove_page(struct supplemental_page_table *spt, struct page *page)
@@ -212,7 +217,7 @@ vm_evict_frame(void)
 static struct frame *
 vm_get_frame(void)
 {
-	struct frame *frame = NULL;
+	struct frame *frame = palloc_get_page(PAL_USER | PAL_ZERO);
 	/* TODO: Fill this function. */
 	/**
 	 * 여기서 swap_out을 진행해야 합니다
@@ -244,7 +249,7 @@ bool vm_try_handle_fault(struct intr_frame *f UNUSED, void *addr UNUSED,
 						 bool user UNUSED, bool write UNUSED, bool not_present UNUSED)
 {
 	struct supplemental_page_table *spt UNUSED = &thread_current()->spt;
-	struct page *page = NULL;
+	struct page *page = spt_find_page(spt, addr);
 	/* TODO: Validate the fault */
 	/* bogus 폴트인지? 스택확장 폴트인지?
 	 * SPT 뒤져서 존재하면 bogus 폴트!!
@@ -313,9 +318,13 @@ static uint64_t my_hash(const struct hash_elem *e, void *aux UNUSED)
 
 static bool my_less(const struct hash_elem *a, const struct hash_elem *b, void *aux UNUSED)
 {
+	if (a == NULL)
+		return true;
+	if (b == NULL)
+		return false;
 	struct SPT_entry *a_entry = hash_entry(a, struct SPT_entry, elem);
 	struct SPT_entry *b_entry = hash_entry(b, struct SPT_entry, elem);
-	return (uint64_t)a_entry->va < (uint64_t)b_entry->va;
+	return a_entry->va < b_entry->va;
 }
 
 /* Copy supplemental page table from src to dst */
@@ -323,7 +332,8 @@ bool supplemental_page_table_copy(struct supplemental_page_table *dst UNUSED,
 								  struct supplemental_page_table *src UNUSED)
 {
 	// 예외 처리
-	if (dst == NULL || src == NULL) {
+	if (dst == NULL || src == NULL)
+	{
 		return false;
 	}
 
@@ -332,16 +342,18 @@ bool supplemental_page_table_copy(struct supplemental_page_table *dst UNUSED,
 	hash_first(&i, &src->SPT_hash_list);
 
 	// src SPT의 모든 페이지를 dst SPT로 복사
-	while (hash_next(&i)) {
+	while (hash_next(&i))
+	{
 		struct SPT_entry *src_entry = hash_entry(hash_cur(&i), struct SPT_entry, elem);
-		if (!vm_alloc_page(page_get_type(src_entry),	// 페이지 타입
-			src_entry->page->va,						// 가상 주소
-			src_entry->page->writable)) {				// 쓰기 권한 
-				return false;							// 할당 실패!
-			}
+		if (!vm_alloc_page(page_get_type(src_entry), // 페이지 타입
+						   src_entry->page->va,		 // 가상 주소
+						   src_entry->page->writable))
+		{				  // 쓰기 권한
+			return false; // 할당 실패!
+		}
 	}
-	
-	return true;	// 모든 페이지 복사 성공
+
+	return true; // 모든 페이지 복사 성공
 }
 
 /* Free the resource hold by the supplemental page table */
@@ -374,7 +386,7 @@ void frame_table_insert(struct list_elem *elem)
 struct frame *frame_table_remove(void)
 {
 	struct thread *cur = thread_current();
-	if(list_empty(&frame_table)) 
+	if (list_empty(&frame_table))
 		return NULL;
 	return list_entry(list_pop_front(&frame_table), struct frame, elem);
 }


### PR DESCRIPTION
SPT에서 아무런 엔트리도 없을 때 my_less에서 hash_entry로 찾으면 쓰레기 값을 반환해서 문제가 생겼었음 a나 b가 NULL일 때를 처리해서 문제 해결