### PR TITLE
[FIX] : anon 물리 주소 초기화

### DIFF
--- a/pintos-kaist/vm/anon.c
+++ b/pintos-kaist/vm/anon.c
@@ -58,6 +58,11 @@ bool anon_initializer(struct page *page, enum vm_type type, void *kva)
 	/* swap index 초기화 */
 	anon_page->swap_idx = -1;
 
+	/* 물리 주소 초기화 */
+	if (kva != NULL) {
+		memset(kva, 0, PGSIZE);
+	}
+
 	return true;
 }
 


### PR DESCRIPTION
Message body
anon.c에 anon_initializer에 kva(물리 주소)를 memset으로 0으로 싹다 초기화 anon은 추적할 수 없기 때문

Message footer
Project 3 : VM