### PR TITLE
[Fix] pt-write-code 오류 수정

### DIFF
--- a/pintos-kaist/vm/vm.c
+++ b/pintos-kaist/vm/vm.c
@@ -255,6 +255,7 @@ bool vm_try_handle_fault(struct intr_frame *f UNUSED, void *addr UNUSED,
 	struct supplemental_page_table *spt UNUSED = &thread_current()->spt;
 	addr = pg_round_down(addr);
 
+	
 	uintptr_t rsp = thread_current()->user_rsp; // 유저 스택의 rsp 가져오기
 
 	if ((uintptr_t)addr >= rsp - STACK_GROW_RANGE && addr < USER_STACK && addr >= USER_STACK - (1 << 20))
@@ -264,9 +265,15 @@ bool vm_try_handle_fault(struct intr_frame *f UNUSED, void *addr UNUSED,
 	}
 
 	struct page *page = spt_find_page(spt, addr);
-	if (page == NULL)
-		return false; // 찐 폴트
+	if (page == NULL){
+		return false;
+	}
+		 // 찐 폴트
 
+
+	if (write == true && !page->writable)
+		return false;
+	
 	ASSERT(page->operations != NULL && page->operations->swap_in != NULL);
 
 	/* TODO: Validate the fault */


### PR DESCRIPTION
변경 사항 요약
-syscall.c
 check_buffer 함수 수정 pml4 조회 성공 시, writeable과 PTE의 is_writeable 상태 검증 조건문 추가
 read 실행 시 writeable = true (파일 조회 후 버퍼 페이지에 작성이므로)
 wirte 실행 시 writeable = farse (버퍼페이지 조회 후 파일에 작성이므로)

-vm.c
  vm_try_handle_fault 내, write 작업일 때, page->writeable이 꺼져있을 경우 false 반환하는 조건문 추가 