### PR TITLE
test all pass

### DIFF
--- a/pintos-kaist/include/vm/vm.h
+++ b/pintos-kaist/include/vm/vm.h
@@ -73,6 +73,8 @@ struct page
 struct frame
 {
 	void *kva;
+	/* extra-cow */
+	int ref_cnt;
 	struct page *page;
 	// frame_table 소속 elem
 	struct list_elem elem;
@@ -159,5 +161,6 @@ struct mmap_info *make_mmap_info(struct lazy_load_info *info,
 struct lazy_load_info *make_info(
 	struct file *file, off_t offset, size_t read_byte);
 
-#endif /* VM_VM_H */
+bool vm_copy_claim_page(void *va, struct page *parent, struct supplemental_page_table *parent_spt);
 
+#endif /* VM_VM_H */

--- a/pintos-kaist/userprog/exception.c
+++ b/pintos-kaist/userprog/exception.c
@@ -155,6 +155,8 @@ page_fault(struct intr_frame *f)
 	write = (f->error_code & PF_W) != 0;
 	user = (f->error_code & PF_U) != 0;
 
+	dprintf("[thread] : %s, Page fault at %p, rip=%p\n", thread_current()->name, fault_addr, f->rip);
+
 #ifdef VM
 	/* For project 3 and later. */
 	if (vm_try_handle_fault(f, fault_addr, user, write, not_present))

--- a/pintos-kaist/userprog/process.c
+++ b/pintos-kaist/userprog/process.c
@@ -388,7 +388,6 @@ void process_exit(void)
       file_close(curr->running_file);
    }
 
-   dprintf("process_exit, 현재 쓰레드 : %s, hash size : %lu\n", curr->name, hash_size(&curr->spt.SPT_hash_list));
    process_cleanup();
    sema_up(&curr->wait_sema);
    sema_down(&curr->free_sema);
@@ -401,7 +400,6 @@ process_cleanup(void)
    struct thread *curr = thread_current();
 
 #ifdef VM
-   dprintf("process_cleanup, 현재 쓰레드 : %s, hash size : %lu\n", curr->name, hash_size(&curr->spt.SPT_hash_list));
    supplemental_page_table_kill(&curr->spt);
 #endif
 

--- a/pintos-kaist/userprog/syscall.c
+++ b/pintos-kaist/userprog/syscall.c
@@ -227,9 +227,15 @@ void check_write_buffer(const void *buffer, unsigned size)
 		{
 			// 이미 매핑되어 있다면 write 권한 확인
 			uint64_t *pte = pml4e_walk(cur->pml4, (uint64_t)addr, false);
-			if (pte == NULL || !is_writable(pte))
+			struct page *cur_page = spt_find_page(&cur->spt, addr);
+			bool page_writable = cur_page->writable;
+			if (pte == NULL || (!is_writable(pte) && !page_writable))
 			{
 				sys_exit(-1); // 쓰기 권한이 없으면 종료
+			}
+			else if (pte == NULL || (!is_writable(pte) && page_writable))
+			{
+				vm_try_handle_fault(NULL, addr, true, true, true);
 			}
 		}
 	}

--- a/pintos-kaist/vm/anon.c
+++ b/pintos-kaist/vm/anon.c
@@ -4,6 +4,7 @@
 #include "threads/vaddr.h"
 #include "lib/kernel/bitmap.h"
 #include "devices/disk.h"
+#include "threads/mmu.h"
 
 /* DO NOT MODIFY BELOW LINE */
 static struct disk *swap_disk;
@@ -28,7 +29,8 @@ void vm_anon_init(void)
 	swap_disk = disk_get(1, 1);
 
 	// 예외 처리
-	if (swap_disk == NULL) {
+	if (swap_disk == NULL)
+	{
 		PANIC("CAN'T FIND SWAP DISK!");
 	}
 
@@ -37,27 +39,29 @@ void vm_anon_init(void)
 	 * 스왑 테이블 엔트리에 이 엔트리가 비어있다는 비트 필요
 	 * bitmap 공부가 필요할듯
 	 */
-	swap_table = bitmap_create(disk_size(swap_disk) /(PGSIZE / DISK_SECTOR_SIZE));
+	swap_table = bitmap_create(disk_size(swap_disk) / (PGSIZE / DISK_SECTOR_SIZE));
 }
 
 /* Initialize the file mapping */
 bool anon_initializer(struct page *page, enum vm_type type, void *kva)
-{	
+{
 	// 들어온 page가 null일 경우
-	if (page == NULL) {
+	if (page == NULL)
+	{
 		return false;
 	}
 	/* Set up the handler */
 	page->operations = &anon_ops;
 
 	/* uninit을 anon으로 변환 */
-	struct anon_page *anon_page = &page->anon;		// page->anon은 포인터가 아니라 구조체 자체여서 항상 유효한 주소를 반환함
-	
+	struct anon_page *anon_page = &page->anon; // page->anon은 포인터가 아니라 구조체 자체여서 항상 유효한 주소를 반환함
+
 	/* swap index 초기화 */
 	anon_page->swap_idx = -1;
 
 	/* 물리 주소 초기화 */
-	if (kva != NULL) {
+	if (kva != NULL && page->frame->ref_cnt <= 1)
+	{
 		memset(kva, 0, PGSIZE);
 	}
 
@@ -72,11 +76,12 @@ anon_swap_in(struct page *page, void *kva)
 	int swap_idx = anon_page->swap_idx;
 
 	// 예외 처리 → swap_idx가 -1이면 페이지가 스왑아웃된 적이 없거나 이미 복구되었으므로 스왑 인 생략
-	if (swap_idx < 0) {
+	if (swap_idx < 0)
+	{
 		return false;
 	}
 	// disk_read에서 사용할 버퍼
-	//void *buffer[PGSIZE];
+	// void *buffer[PGSIZE];
 	/** TODO: 페이지 스왑 인
 	 * disk_read를 데이터를 읽고 kva에 데이터 복사
 	 * swap_idx를 -1로 바꿔주어야 함
@@ -88,10 +93,11 @@ anon_swap_in(struct page *page, void *kva)
 	// 총 8개의 섹터를 순차적으로 읽어야 전체 페이지 데이터를 복원할 수 있음
 	// swap_idx는 스왑 테이블 상의 페이지 단위 인덱스를 의미하며,
 	// 실제 섹터 번호는 swap_idx * 8부터 시작함
-	for (int i = 0; i < 8; i++) {
-		disk_read(swap_disk,                            // 스왑 디스크에서 데이터를 읽어옴
-				(swap_idx * 8) + i,                    // 8개의 연속된 섹터에 페이지가 저장되어 있으므로, i를 더해가며 읽음
-				kva + (DISK_SECTOR_SIZE * i));         // 읽어온 데이터를 커널 가상 주소 kva에 512B 단위로 복사
+	for (int i = 0; i < 8; i++)
+	{
+		disk_read(swap_disk,					 // 스왑 디스크에서 데이터를 읽어옴
+				  (swap_idx * 8) + i,			 // 8개의 연속된 섹터에 페이지가 저장되어 있으므로, i를 더해가며 읽음
+				  kva + (DISK_SECTOR_SIZE * i)); // 읽어온 데이터를 커널 가상 주소 kva에 512B 단위로 복사
 	}
 
 	// 스왑 테이블에서 해당 스왑 슬롯을 비어있다고 표시 (해당 슬롯 재사용 가능하도록)
@@ -106,9 +112,10 @@ anon_swap_in(struct page *page, void *kva)
 /* 페이지의 내용을 스왑 디스크에 기록하여 스왑아웃합니다. */
 static bool
 anon_swap_out(struct page *page)
-{	
+{
 	// page 인자의 예외 처리
-	if (page == NULL) {
+	if (page == NULL)
+	{
 		return false;
 	}
 	struct anon_page *anon_page = &page->anon;
@@ -118,19 +125,21 @@ anon_swap_out(struct page *page)
 	 * 검색된 스왑 슬롯 인덱스를 anon_page에 저장
 	 * disk_write를 통해 해당 디스크 섹터에 저장
 	 */
-	
+
 	size_t swap_idx = bitmap_scan_and_flip(swap_table, 0, 1, false);
-	
-	if (swap_idx == BITMAP_ERROR) {
-		ASSERT(bitmap_test(swap_table, swap_idx) == false); 
+
+	if (swap_idx == BITMAP_ERROR)
+	{
+		ASSERT(bitmap_test(swap_table, swap_idx) == false);
 		return false;
 	}
 
 	// swap in에 자세히 주석을 달아 놓았음 잘 살펴 보셈
-	for(int i = 0; i < 8; i++) {
+	for (int i = 0; i < 8; i++)
+	{
 		disk_write(swap_disk, (swap_idx * 8) + i, page->frame->kva + (DISK_SECTOR_SIZE * i));
 	}
-	
+
 	// 페이지와 프레임 간의 연결을 끊음 (프레임은 더 이상 이 페이지를 참조 하지 않음)
 	page->frame->page = NULL;
 	page->frame = NULL;
@@ -147,7 +156,9 @@ anon_destroy(struct page *page)
 {
 	struct anon_page *anon_page = &page->anon;
 	// swap_idx가 0보다 작을 경우는 페이지가 스왑 아웃이 된 적이 없거나 이미 복구 되어 swap_idx가 -1이면 추가 작업 X, 종료
-	if(anon_page->swap_idx < 0) {
+	pml4_clear_page(thread_current()->pml4, page->va);
+	if (anon_page->swap_idx < 0)
+	{
 		return;
 	}
 

--- a/pintos-kaist/vm/file.c
+++ b/pintos-kaist/vm/file.c
@@ -75,7 +75,8 @@ file_backed_swap_in(struct page *page, void *kva)
 	size_t read_byte = file_page->read_byte;
 
 	// 파일에서 데이터를 읽어와 kva(페이지가 매핑된 커널 가상 주소)에 저장
-	if (file_read_at(file, kva, read_byte, offset) != (off_t)read_byte) {
+	if (file_read_at(file, kva, read_byte, offset) != (off_t)read_byte)
+	{
 		// 읽은 바이트 수가 기대치와 다르면 오류 처리
 		return false;
 	}
@@ -102,17 +103,19 @@ file_backed_swap_out(struct page *page)
 	bool dirty_bit = pml4_is_dirty(curr->pml4, page->va);
 
 	// dirty bit가 true이면, 즉 메모리에서 수정된 경우
-	if (dirty_bit == true) {
+	if (dirty_bit == true)
+	{
 		// 공유 자원 접근 → 락 걸고 접근
 		lock_acquire(&filesys_lock);
-		if (file_write_at(file_page->file,			// mmap된 파일 객체
-						page->frame->kva,			// 페이지의 실제 물리 주소
-						file_page->read_byte,		// 실제로 파일에 기록할 바이트 수
-						file_page->offset)			// 파일 내 시작 위치
-			!= (off_t)file_page->read_byte) {
-				// write 실패하면 lock 해제 해야겠지? 
-				lock_release(&filesys_lock);
-				return false;
+		if (file_write_at(file_page->file,		// mmap된 파일 객체
+						  page->frame->kva,		// 페이지의 실제 물리 주소
+						  file_page->read_byte, // 실제로 파일에 기록할 바이트 수
+						  file_page->offset)	// 파일 내 시작 위치
+			!= (off_t)file_page->read_byte)
+		{
+			// write 실패하면 lock 해제 해야겠지?
+			lock_release(&filesys_lock);
+			return false;
 		}
 		// 파일 쓰기 완료 후 락 해제
 		lock_release(&filesys_lock);
@@ -120,7 +123,7 @@ file_backed_swap_out(struct page *page)
 		// 더티 비트 클리어(쓰기 완!)
 		pml4_set_dirty(curr->pml4, page->va, false);
 	}
-	//초기화는 victim에서 
+	// 초기화는 victim에서
 	page->frame->page = NULL;
 	page->frame = NULL;
 
@@ -130,7 +133,7 @@ file_backed_swap_out(struct page *page)
 /* 파일 기반 페이지를 소멸시킵니다. PAGE는 호출자가 해제합니다. */
 static void
 file_backed_destroy(struct page *page)
-{	
+{
 	// file_page는 file-backed 페이지에 대한 메타데이터를 담고 있는 구조체
 	struct file_page *file_page UNUSED = &page->file;
 	/** TODO: dirty_bit 확인 후 write_back
@@ -147,10 +150,10 @@ file_backed_destroy(struct page *page)
 	if (pml4_is_dirty(thread_current()->pml4, page->va))
 	{
 		lock_acquire(&filesys_lock);
-		off_t written = file_write_at(file_page->file,			// mmap으로 매핑된 파일 객체
-									page->frame->kva,			// 물리 메모리 상 해당 페이지의 커널 주소
-									file_page->read_byte, 		// 실제로 파일에 쓸 바이트 수
-									file_page->offset);			// mmap할 때 저장된 파일 내부의 오프셋 위치
+		off_t written = file_write_at(file_page->file,		// mmap으로 매핑된 파일 객체
+									  page->frame->kva,		// 물리 메모리 상 해당 페이지의 커널 주소
+									  file_page->read_byte, // 실제로 파일에 쓸 바이트 수
+									  file_page->offset);	// mmap할 때 저장된 파일 내부의 오프셋 위치
 		lock_release(&filesys_lock);
 		ASSERT(written == file_page->read_byte);
 
@@ -159,8 +162,8 @@ file_backed_destroy(struct page *page)
 	}
 
 	// 해당 페이지가 물리 프레임에 매핑되어 있으면
-	if (page->frame != NULL)
-	{	
+	if (page->frame != NULL && page->frame->ref_cnt < 1)
+	{
 		// 물리 페이지를 해제하고, frame 구조체도 동적 메모리 해제
 		palloc_free_page(page->frame->kva);
 		free(page->frame);

--- a/pintos-kaist/vm/vm.c
+++ b/pintos-kaist/vm/vm.c
@@ -265,6 +265,7 @@ vm_get_frame(void)
       free(victim1);
    }
    frame->page = NULL;
+   frame->ref_cnt = 1;
    frame_table_insert(&frame->elem);
 
    ASSERT(frame->page == NULL);
@@ -285,6 +286,30 @@ vm_stack_growth(void *addr UNUSED)
 static bool
 vm_handle_wp(struct page *page UNUSED)
 {
+   if (page == NULL)
+   {
+      return false;
+   }
+   struct frame *copy_frame = page->frame;
+
+   if (copy_frame->ref_cnt > 1)
+   {
+      struct frame *frame = vm_get_frame();
+      page->frame = frame;
+      memcpy(frame->kva, copy_frame->kva, PGSIZE);
+      copy_frame->ref_cnt--;
+
+      if (!pml4_set_page(thread_current()->pml4, page->va, frame->kva, true))
+         return false;
+   }
+   else
+   {
+      copy_frame->page = page;
+      if (!pml4_set_page(thread_current()->pml4, page->va, copy_frame->kva, true))
+         return false;
+   }
+
+   return true;
 }
 
 /* Return true on success */
@@ -321,6 +346,9 @@ bool vm_try_handle_fault(struct intr_frame *f UNUSED, void *addr UNUSED,
    if (write == true && !page->writable)
       return false;
 
+   if (write == true && page->writable && page->frame != NULL)
+      return vm_handle_wp(page);
+
    ASSERT(page->operations != NULL && page->operations->swap_in != NULL);
 
    return vm_do_claim_page(page);
@@ -330,11 +358,14 @@ bool vm_try_handle_fault(struct intr_frame *f UNUSED, void *addr UNUSED,
  * DO NOT MODIFY THIS FUNCTION. */
 void vm_dealloc_page(struct page *page)
 {
-   destroy(page);
+   page->frame->ref_cnt--;
+
+   if (page->frame->ref_cnt == 0)
+      destroy(page);
    free(page);
 }
 
-/* VA에 할당된 페이지를 요구합니다 . */
+/* VA에 할당된 페이지를 요구합니다 . 왜 맨날 요구만 함. */
 bool vm_claim_page(void *va UNUSED)
 {
    struct page *page = spt_find_page(&thread_current()->spt, va); // 스택 첫번째페이지
@@ -344,7 +375,7 @@ bool vm_claim_page(void *va UNUSED)
    return vm_do_claim_page(page);
 }
 
-/* PAGE를 요구하고 mmu를 설정합니다*/
+/* PAGE를 요구하고 mmu를 설정합니다. 근데 저는 안할겁니다.*/
 static bool
 vm_do_claim_page(struct page *page)
 {
@@ -357,6 +388,29 @@ vm_do_claim_page(struct page *page)
 
    /* TODO: Insert page table entry to map page's VA to frame's PA. */
    if (!pml4_set_page(thread_current()->pml4, page->va, frame->kva, page->writable))
+      return false;
+
+   return swap_in(page, frame->kva);
+}
+
+bool vm_copy_claim_page(void *va, struct page *parent, struct supplemental_page_table *parent_spt)
+{
+   struct page *page = spt_find_page(&thread_current()->spt, va); // 스택 첫번째페이지
+   if (page == NULL)
+      return false;
+
+   void *temp = page->operations->swap_in;
+   struct frame *frame = parent->frame;
+   frame->ref_cnt++;
+
+   if (frame->ref_cnt == 1)
+      return true;
+
+   /* Set links */
+   page->frame = frame;
+
+   /* TODO: Insert page table entry to map page's VA to frame's PA. */
+   if (!pml4_set_page(thread_current()->pml4, page->va, frame->kva, false))
       return false;
 
    return swap_in(page, frame->kva);
@@ -456,7 +510,7 @@ bool supplemental_page_table_copy(struct supplemental_page_table *dst UNUSED, st
             return false;
 
          /* 부모에서 이미 초기화된 페이지이기에 바로 명시적 초기화 호출 */
-         if (!vm_claim_page(upage))
+         if (!vm_copy_claim_page(upage, src_page, dst))
             return false;
 
          continue;
@@ -469,7 +523,7 @@ bool supplemental_page_table_copy(struct supplemental_page_table *dst UNUSED, st
          return false;
 
       // vm_claim_page으로 요청해서 매핑 & 페이지 타입에 맞게 초기화
-      if (!vm_claim_page(upage))
+      if (!vm_copy_claim_page(upage, src_page, dst))
          return false;
 
       // 매핑된 프레임에 내용 로딩


### PR DESCRIPTION
## 테스트 실패 원인
1. 공유된 프레임을 가리키는 페이지가 파괴될 때 pml4_clear를 호출해주지 않아서 프로세스가 종료될 때 pml4_destroy 에서 동일한 물리 프레임을 또 해제하려다가 문제가 생김
- anon_destroy에 plm4_clear_page 추가
3. vm_try_handle_fault에서 복사해온 스택 영역에서 write_fault가 발생할 때 spt_find_page를 먼저 하지 않고 스택 확장 검사를 먼저 해버려서 동일한 가상 영역에 덮어쓰는 대참사가 일어났었음
- vm_try_handle_fault에서 폴트 검사 순서 바꿈